### PR TITLE
feat(proto): improve BCE in int decoding

### DIFF
--- a/proto/cmd/ch-gen-col/main.tpl
+++ b/proto/cmd/ch-gen-col/main.tpl
@@ -85,6 +85,9 @@ func (c {{ .Type }}) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes {{ .Name }} rows from *Reader.
 func (c *{{ .Type }}) DecodeColumn(r *Reader, rows int) error {
+  if rows == 0 {
+    return nil
+  }
   {{- if .SingleByte }}
   data, err := r.ReadRaw(rows)
   {{- else }}

--- a/proto/cmd/ch-gen-col/main.tpl
+++ b/proto/cmd/ch-gen-col/main.tpl
@@ -105,7 +105,11 @@ func (c *{{ .Type }}) DecodeColumn(r *Reader, rows int) error {
   *c = v
   {{- else }}
   v := *c
-  for i := 0; i < len(data); i += size {
+  // Move bound check out of loop.
+  //
+  // See https://github.com/golang/go/issues/30945.
+  _ = data[len(data)-size]
+  for i := 0; i <= len(data)-size; i += size {
     v = append(v,
     {{- if .IsFloat }}
       math.{{ .Name }}frombits(bin.{{ .BinFunc }}(data[i:i+size])),

--- a/proto/cmd/ch-gen-col/test.tpl
+++ b/proto/cmd/ch-gen-col/test.tpl
@@ -37,6 +37,12 @@ func Test{{ .Type }}_DecodeColumn(t *testing.T) {
     require.Equal(t, 0, dec.Rows())
     require.Equal(t, {{ .ColumnType }}, dec.Type())
   })
+  t.Run("ZeroRows", func(t *testing.T) {
+    r := NewReader(bytes.NewReader(nil))
+
+    var dec {{ .Type }}
+    require.NoError(t, dec.DecodeColumn(r, 0))
+  })
   t.Run("ErrUnexpectedEOF", func(t *testing.T) {
     r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_date32_gen.go
+++ b/proto/col_date32_gen.go
@@ -71,7 +71,11 @@ func (c *ColDate32) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			Date32(binary.LittleEndian.Uint32(data[i:i+size])),
 		)

--- a/proto/col_date32_gen.go
+++ b/proto/col_date32_gen.go
@@ -65,6 +65,9 @@ func (c ColDate32) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Date32 rows from *Reader.
 func (c *ColDate32) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 32 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_date32_gen_test.go
+++ b/proto/col_date32_gen_test.go
@@ -36,6 +36,12 @@ func TestColDate32_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeDate32, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColDate32
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_date_gen.go
+++ b/proto/col_date_gen.go
@@ -65,6 +65,9 @@ func (c ColDate) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Date rows from *Reader.
 func (c *ColDate) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 16 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_date_gen.go
+++ b/proto/col_date_gen.go
@@ -71,7 +71,11 @@ func (c *ColDate) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			Date(binary.LittleEndian.Uint16(data[i:i+size])),
 		)

--- a/proto/col_date_gen_test.go
+++ b/proto/col_date_gen_test.go
@@ -36,6 +36,12 @@ func TestColDate_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeDate, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColDate
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_datetime64_gen.go
+++ b/proto/col_datetime64_gen.go
@@ -65,6 +65,9 @@ func (c ColDateTime64) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes DateTime64 rows from *Reader.
 func (c *ColDateTime64) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 64 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_datetime64_gen.go
+++ b/proto/col_datetime64_gen.go
@@ -71,7 +71,11 @@ func (c *ColDateTime64) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			DateTime64(binary.LittleEndian.Uint64(data[i:i+size])),
 		)

--- a/proto/col_datetime64_gen_test.go
+++ b/proto/col_datetime64_gen_test.go
@@ -36,6 +36,12 @@ func TestColDateTime64_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeDateTime64, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColDateTime64
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_datetime_gen.go
+++ b/proto/col_datetime_gen.go
@@ -71,7 +71,11 @@ func (c *ColDateTime) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			DateTime(binary.LittleEndian.Uint32(data[i:i+size])),
 		)

--- a/proto/col_datetime_gen.go
+++ b/proto/col_datetime_gen.go
@@ -65,6 +65,9 @@ func (c ColDateTime) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes DateTime rows from *Reader.
 func (c *ColDateTime) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 32 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_datetime_gen_test.go
+++ b/proto/col_datetime_gen_test.go
@@ -36,6 +36,12 @@ func TestColDateTime_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeDateTime, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColDateTime
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_decimal128_gen.go
+++ b/proto/col_decimal128_gen.go
@@ -71,7 +71,11 @@ func (c *ColDecimal128) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			Decimal128(binUInt128(data[i:i+size])),
 		)

--- a/proto/col_decimal128_gen.go
+++ b/proto/col_decimal128_gen.go
@@ -65,6 +65,9 @@ func (c ColDecimal128) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Decimal128 rows from *Reader.
 func (c *ColDecimal128) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 128 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_decimal128_gen_test.go
+++ b/proto/col_decimal128_gen_test.go
@@ -36,6 +36,12 @@ func TestColDecimal128_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeDecimal128, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColDecimal128
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_decimal256_gen.go
+++ b/proto/col_decimal256_gen.go
@@ -65,6 +65,9 @@ func (c ColDecimal256) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Decimal256 rows from *Reader.
 func (c *ColDecimal256) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 256 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_decimal256_gen.go
+++ b/proto/col_decimal256_gen.go
@@ -71,7 +71,11 @@ func (c *ColDecimal256) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			Decimal256(binUInt256(data[i:i+size])),
 		)

--- a/proto/col_decimal256_gen_test.go
+++ b/proto/col_decimal256_gen_test.go
@@ -36,6 +36,12 @@ func TestColDecimal256_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeDecimal256, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColDecimal256
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_decimal32_gen.go
+++ b/proto/col_decimal32_gen.go
@@ -71,7 +71,11 @@ func (c *ColDecimal32) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			Decimal32(binary.LittleEndian.Uint32(data[i:i+size])),
 		)

--- a/proto/col_decimal32_gen.go
+++ b/proto/col_decimal32_gen.go
@@ -65,6 +65,9 @@ func (c ColDecimal32) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Decimal32 rows from *Reader.
 func (c *ColDecimal32) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 32 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_decimal32_gen_test.go
+++ b/proto/col_decimal32_gen_test.go
@@ -36,6 +36,12 @@ func TestColDecimal32_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeDecimal32, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColDecimal32
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_decimal64_gen.go
+++ b/proto/col_decimal64_gen.go
@@ -71,7 +71,11 @@ func (c *ColDecimal64) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			Decimal64(binary.LittleEndian.Uint64(data[i:i+size])),
 		)

--- a/proto/col_decimal64_gen.go
+++ b/proto/col_decimal64_gen.go
@@ -65,6 +65,9 @@ func (c ColDecimal64) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Decimal64 rows from *Reader.
 func (c *ColDecimal64) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 64 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_decimal64_gen_test.go
+++ b/proto/col_decimal64_gen_test.go
@@ -36,6 +36,12 @@ func TestColDecimal64_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeDecimal64, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColDecimal64
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_enum16_gen.go
+++ b/proto/col_enum16_gen.go
@@ -71,7 +71,11 @@ func (c *ColEnum16) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			Enum16(binary.LittleEndian.Uint16(data[i:i+size])),
 		)

--- a/proto/col_enum16_gen.go
+++ b/proto/col_enum16_gen.go
@@ -65,6 +65,9 @@ func (c ColEnum16) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Enum16 rows from *Reader.
 func (c *ColEnum16) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 16 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_enum16_gen_test.go
+++ b/proto/col_enum16_gen_test.go
@@ -36,6 +36,12 @@ func TestColEnum16_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeEnum16, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColEnum16
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_enum8_gen.go
+++ b/proto/col_enum8_gen.go
@@ -60,6 +60,9 @@ func (c ColEnum8) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Enum8 rows from *Reader.
 func (c *ColEnum8) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	data, err := r.ReadRaw(rows)
 	if err != nil {
 		return errors.Wrap(err, "read")

--- a/proto/col_enum8_gen_test.go
+++ b/proto/col_enum8_gen_test.go
@@ -36,6 +36,12 @@ func TestColEnum8_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeEnum8, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColEnum8
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_float32_gen.go
+++ b/proto/col_float32_gen.go
@@ -66,6 +66,9 @@ func (c ColFloat32) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Float32 rows from *Reader.
 func (c *ColFloat32) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 32 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_float32_gen.go
+++ b/proto/col_float32_gen.go
@@ -72,7 +72,11 @@ func (c *ColFloat32) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			math.Float32frombits(bin.Uint32(data[i:i+size])),
 		)

--- a/proto/col_float32_gen_test.go
+++ b/proto/col_float32_gen_test.go
@@ -36,6 +36,12 @@ func TestColFloat32_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeFloat32, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColFloat32
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_float64_gen.go
+++ b/proto/col_float64_gen.go
@@ -72,7 +72,11 @@ func (c *ColFloat64) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			math.Float64frombits(bin.Uint64(data[i:i+size])),
 		)

--- a/proto/col_float64_gen.go
+++ b/proto/col_float64_gen.go
@@ -66,6 +66,9 @@ func (c ColFloat64) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Float64 rows from *Reader.
 func (c *ColFloat64) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 64 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_float64_gen_test.go
+++ b/proto/col_float64_gen_test.go
@@ -36,6 +36,12 @@ func TestColFloat64_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeFloat64, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColFloat64
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_int128_gen.go
+++ b/proto/col_int128_gen.go
@@ -65,6 +65,9 @@ func (c ColInt128) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Int128 rows from *Reader.
 func (c *ColInt128) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 128 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_int128_gen.go
+++ b/proto/col_int128_gen.go
@@ -71,7 +71,11 @@ func (c *ColInt128) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			Int128(binUInt128(data[i:i+size])),
 		)

--- a/proto/col_int128_gen_test.go
+++ b/proto/col_int128_gen_test.go
@@ -36,6 +36,12 @@ func TestColInt128_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeInt128, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColInt128
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_int16_gen.go
+++ b/proto/col_int16_gen.go
@@ -71,7 +71,11 @@ func (c *ColInt16) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			int16(binary.LittleEndian.Uint16(data[i:i+size])),
 		)

--- a/proto/col_int16_gen.go
+++ b/proto/col_int16_gen.go
@@ -65,6 +65,9 @@ func (c ColInt16) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Int16 rows from *Reader.
 func (c *ColInt16) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 16 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_int16_gen_test.go
+++ b/proto/col_int16_gen_test.go
@@ -36,6 +36,12 @@ func TestColInt16_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeInt16, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColInt16
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_int256_gen.go
+++ b/proto/col_int256_gen.go
@@ -65,6 +65,9 @@ func (c ColInt256) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Int256 rows from *Reader.
 func (c *ColInt256) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 256 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_int256_gen.go
+++ b/proto/col_int256_gen.go
@@ -71,7 +71,11 @@ func (c *ColInt256) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			Int256(binUInt256(data[i:i+size])),
 		)

--- a/proto/col_int256_gen_test.go
+++ b/proto/col_int256_gen_test.go
@@ -36,6 +36,12 @@ func TestColInt256_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeInt256, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColInt256
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_int32_gen.go
+++ b/proto/col_int32_gen.go
@@ -71,7 +71,11 @@ func (c *ColInt32) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			int32(binary.LittleEndian.Uint32(data[i:i+size])),
 		)

--- a/proto/col_int32_gen.go
+++ b/proto/col_int32_gen.go
@@ -65,6 +65,9 @@ func (c ColInt32) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Int32 rows from *Reader.
 func (c *ColInt32) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 32 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_int32_gen_test.go
+++ b/proto/col_int32_gen_test.go
@@ -36,6 +36,12 @@ func TestColInt32_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeInt32, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColInt32
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_int64_gen.go
+++ b/proto/col_int64_gen.go
@@ -71,7 +71,11 @@ func (c *ColInt64) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			int64(binary.LittleEndian.Uint64(data[i:i+size])),
 		)

--- a/proto/col_int64_gen.go
+++ b/proto/col_int64_gen.go
@@ -65,6 +65,9 @@ func (c ColInt64) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Int64 rows from *Reader.
 func (c *ColInt64) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 64 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_int64_gen_test.go
+++ b/proto/col_int64_gen_test.go
@@ -36,6 +36,12 @@ func TestColInt64_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeInt64, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColInt64
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_int8_gen.go
+++ b/proto/col_int8_gen.go
@@ -60,6 +60,9 @@ func (c ColInt8) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes Int8 rows from *Reader.
 func (c *ColInt8) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	data, err := r.ReadRaw(rows)
 	if err != nil {
 		return errors.Wrap(err, "read")

--- a/proto/col_int8_gen_test.go
+++ b/proto/col_int8_gen_test.go
@@ -36,6 +36,12 @@ func TestColInt8_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeInt8, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColInt8
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_ipv4_gen.go
+++ b/proto/col_ipv4_gen.go
@@ -71,7 +71,11 @@ func (c *ColIPv4) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			IPv4(binary.LittleEndian.Uint32(data[i:i+size])),
 		)

--- a/proto/col_ipv4_gen.go
+++ b/proto/col_ipv4_gen.go
@@ -65,6 +65,9 @@ func (c ColIPv4) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes IPv4 rows from *Reader.
 func (c *ColIPv4) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 32 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_ipv4_gen_test.go
+++ b/proto/col_ipv4_gen_test.go
@@ -36,6 +36,12 @@ func TestColIPv4_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeIPv4, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColIPv4
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_ipv6_gen.go
+++ b/proto/col_ipv6_gen.go
@@ -65,6 +65,9 @@ func (c ColIPv6) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes IPv6 rows from *Reader.
 func (c *ColIPv6) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 128 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_ipv6_gen.go
+++ b/proto/col_ipv6_gen.go
@@ -71,7 +71,11 @@ func (c *ColIPv6) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			binIPv6(data[i:i+size]),
 		)

--- a/proto/col_ipv6_gen_test.go
+++ b/proto/col_ipv6_gen_test.go
@@ -36,6 +36,12 @@ func TestColIPv6_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeIPv6, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColIPv6
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_uint128_gen.go
+++ b/proto/col_uint128_gen.go
@@ -71,7 +71,11 @@ func (c *ColUInt128) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			binUInt128(data[i:i+size]),
 		)

--- a/proto/col_uint128_gen.go
+++ b/proto/col_uint128_gen.go
@@ -65,6 +65,9 @@ func (c ColUInt128) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes UInt128 rows from *Reader.
 func (c *ColUInt128) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 128 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_uint128_gen_test.go
+++ b/proto/col_uint128_gen_test.go
@@ -36,6 +36,12 @@ func TestColUInt128_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeUInt128, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColUInt128
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_uint16_gen.go
+++ b/proto/col_uint16_gen.go
@@ -71,7 +71,11 @@ func (c *ColUInt16) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			binary.LittleEndian.Uint16(data[i:i+size]),
 		)

--- a/proto/col_uint16_gen.go
+++ b/proto/col_uint16_gen.go
@@ -65,6 +65,9 @@ func (c ColUInt16) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes UInt16 rows from *Reader.
 func (c *ColUInt16) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 16 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_uint16_gen_test.go
+++ b/proto/col_uint16_gen_test.go
@@ -36,6 +36,12 @@ func TestColUInt16_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeUInt16, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColUInt16
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_uint256_gen.go
+++ b/proto/col_uint256_gen.go
@@ -65,6 +65,9 @@ func (c ColUInt256) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes UInt256 rows from *Reader.
 func (c *ColUInt256) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 256 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_uint256_gen.go
+++ b/proto/col_uint256_gen.go
@@ -71,7 +71,11 @@ func (c *ColUInt256) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			binUInt256(data[i:i+size]),
 		)

--- a/proto/col_uint256_gen_test.go
+++ b/proto/col_uint256_gen_test.go
@@ -36,6 +36,12 @@ func TestColUInt256_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeUInt256, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColUInt256
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_uint32_gen.go
+++ b/proto/col_uint32_gen.go
@@ -65,6 +65,9 @@ func (c ColUInt32) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes UInt32 rows from *Reader.
 func (c *ColUInt32) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 32 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_uint32_gen.go
+++ b/proto/col_uint32_gen.go
@@ -71,7 +71,11 @@ func (c *ColUInt32) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			binary.LittleEndian.Uint32(data[i:i+size]),
 		)

--- a/proto/col_uint32_gen_test.go
+++ b/proto/col_uint32_gen_test.go
@@ -36,6 +36,12 @@ func TestColUInt32_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeUInt32, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColUInt32
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_uint64_gen.go
+++ b/proto/col_uint64_gen.go
@@ -65,6 +65,9 @@ func (c ColUInt64) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes UInt64 rows from *Reader.
 func (c *ColUInt64) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	const size = 64 / 8
 	data, err := r.ReadRaw(rows * size)
 	if err != nil {

--- a/proto/col_uint64_gen.go
+++ b/proto/col_uint64_gen.go
@@ -71,7 +71,11 @@ func (c *ColUInt64) DecodeColumn(r *Reader, rows int) error {
 		return errors.Wrap(err, "read")
 	}
 	v := *c
-	for i := 0; i < len(data); i += size {
+	// Move bound check out of loop.
+	//
+	// See https://github.com/golang/go/issues/30945.
+	_ = data[len(data)-size]
+	for i := 0; i <= len(data)-size; i += size {
 		v = append(v,
 			binary.LittleEndian.Uint64(data[i:i+size]),
 		)

--- a/proto/col_uint64_gen_test.go
+++ b/proto/col_uint64_gen_test.go
@@ -36,6 +36,12 @@ func TestColUInt64_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeUInt64, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColUInt64
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 

--- a/proto/col_uint8_gen.go
+++ b/proto/col_uint8_gen.go
@@ -56,6 +56,9 @@ func (c ColUInt8) EncodeColumn(b *Buffer) {
 
 // DecodeColumn decodes UInt8 rows from *Reader.
 func (c *ColUInt8) DecodeColumn(r *Reader, rows int) error {
+	if rows == 0 {
+		return nil
+	}
 	data, err := r.ReadRaw(rows)
 	if err != nil {
 		return errors.Wrap(err, "read")

--- a/proto/col_uint8_gen_test.go
+++ b/proto/col_uint8_gen_test.go
@@ -36,6 +36,12 @@ func TestColUInt8_DecodeColumn(t *testing.T) {
 		require.Equal(t, 0, dec.Rows())
 		require.Equal(t, ColumnTypeUInt8, dec.Type())
 	})
+	t.Run("ZeroRows", func(t *testing.T) {
+		r := NewReader(bytes.NewReader(nil))
+
+		var dec ColUInt8
+		require.NoError(t, dec.DecodeColumn(r, 0))
+	})
 	t.Run("ErrUnexpectedEOF", func(t *testing.T) {
 		r := NewReader(bytes.NewReader(nil))
 


### PR DESCRIPTION
```
name                          old speed      new speed      delta
ColBool_Raw_DecodeColumn-4    9.25GB/s ± 2%  9.30GB/s ± 2%     ~     (p=0.056 n=15+15)
ColBool_DecodeColumn-4         735MB/s ± 3%   741MB/s ± 1%   +0.70%  (p=0.011 n=14+14)
ColDate32_DecodeColumn-4      2.39GB/s ± 1%  2.91GB/s ± 2%  +21.66%  (p=0.000 n=14+14)
ColDate_DecodeColumn-4        1.27GB/s ± 1%  1.57GB/s ± 0%  +23.32%  (p=0.000 n=14+12)
ColDateTime64_DecodeColumn-4  4.39GB/s ± 2%  5.21GB/s ± 2%  +18.57%  (p=0.000 n=15+15)
ColDateTime_DecodeColumn-4    2.40GB/s ± 1%  2.89GB/s ± 4%  +20.26%  (p=0.000 n=14+14)
ColDecimal128_DecodeColumn-4  3.02GB/s ± 2%  3.02GB/s ± 3%     ~     (p=0.983 n=14+15)
ColDecimal256_DecodeColumn-4  4.20GB/s ± 2%  4.19GB/s ± 3%     ~     (p=0.880 n=14+15)
ColDecimal32_DecodeColumn-4   2.41GB/s ± 1%  2.90GB/s ± 2%  +20.32%  (p=0.000 n=12+13)
ColDecimal64_DecodeColumn-4   4.39GB/s ± 4%  5.21GB/s ± 2%  +18.63%  (p=0.000 n=14+15)
ColEnum16_DecodeColumn-4      1.27GB/s ± 2%  1.56GB/s ± 2%  +22.26%  (p=0.000 n=14+15)
ColEnum8_DecodeColumn-4       1.39GB/s ± 3%  1.41GB/s ± 0%   +1.52%  (p=0.000 n=14+12)
ColFixedStr_DecodeColumn-4    14.1GB/s ± 1%  14.1GB/s ± 1%   -0.20%  (p=0.050 n=14+14)
ColFloat32_DecodeColumn-4     2.41GB/s ± 1%  2.89GB/s ± 2%  +20.19%  (p=0.000 n=14+15)
ColFloat64_DecodeColumn-4     4.40GB/s ± 1%  5.24GB/s ± 1%  +18.95%  (p=0.000 n=14+13)
ColInt128_DecodeColumn-4      3.01GB/s ± 3%  3.00GB/s ± 3%     ~     (p=0.158 n=15+14)
ColInt16_DecodeColumn-4       1.27GB/s ± 3%  1.55GB/s ± 2%  +21.98%  (p=0.000 n=15+15)
ColInt256_DecodeColumn-4      4.21GB/s ± 2%  4.20GB/s ± 4%     ~     (p=0.946 n=14+14)
ColInt32_DecodeColumn-4       2.41GB/s ± 1%  2.92GB/s ± 0%  +21.04%  (p=0.000 n=14+12)
ColInt64_DecodeColumn-4       4.40GB/s ± 2%  5.18GB/s ± 5%  +17.86%  (p=0.000 n=15+14)
ColInt8_DecodeColumn-4        1.40GB/s ± 1%  1.40GB/s ± 1%     ~     (p=0.726 n=14+14)
ColIPv4_DecodeColumn-4        2.41GB/s ± 0%  2.91GB/s ± 2%  +20.57%  (p=0.000 n=12+14)
ColIPv6_DecodeColumn-4        2.85GB/s ± 3%  2.93GB/s ± 2%   +2.66%  (p=0.000 n=14+15)
ColRaw_DecodeColumn-4         14.5GB/s ± 2%  14.6GB/s ± 2%     ~     (p=0.905 n=14+13)
ColStr_DecodeColumn-4          588MB/s ± 0%   549MB/s ± 3%   -6.64%  (p=0.000 n=12+15)
ColTuple_DecodeColumn-4       8.92GB/s ± 3%  8.95GB/s ± 2%     ~     (p=0.323 n=14+14)
ColUInt128_DecodeColumn-4     3.00GB/s ± 2%  3.00GB/s ± 2%     ~     (p=0.621 n=14+15)
ColUInt16_DecodeColumn-4      1.28GB/s ± 1%  1.56GB/s ± 0%  +22.50%  (p=0.000 n=15+12)
ColUInt256_DecodeColumn-4     4.21GB/s ± 3%  4.22GB/s ± 2%     ~     (p=0.880 n=15+14)
ColUInt32_DecodeColumn-4      2.42GB/s ± 0%  2.92GB/s ± 0%  +20.78%  (p=0.000 n=12+12)
ColUInt64_DecodeColumn-4      4.40GB/s ± 2%  5.23GB/s ± 2%  +18.89%  (p=0.000 n=15+14)
ColUInt8_DecodeColumn-4       7.76GB/s ± 2%  7.81GB/s ± 2%     ~     (p=0.141 n=14+13)
ColUUID_DecodeColumn-4        4.36GB/s ± 3%  4.37GB/s ± 1%     ~     (p=0.893 n=14+5)
```