### PR TITLE
feat(proto): optimize encoding

### DIFF
--- a/proto/cmd/ch-gen-col/main.tpl
+++ b/proto/cmd/ch-gen-col/main.tpl
@@ -5,9 +5,6 @@ package proto
 
 import (
 	"encoding/binary"
-{{- if .IsFloat }}
-	"math"
-{{- end }}
 )
 
 var _ = binary.LittleEndian // clickHouse uses LittleEndian
@@ -59,34 +56,4 @@ func (c *ColArr) Append{{ .Name }}(data []{{ .ElemType }}) {
   d := c.Data.(*{{ .Type }})
   *d = append(*d, data...)
   c.Offsets = append(c.Offsets, uint64(len(*d)))
-}
-
-// EncodeColumn encodes {{ .Name }} rows to *Buffer.
-func (c {{ .Type }}) EncodeColumn(b *Buffer) {
-  {{- if .Byte }}
-  b.Buf = append(b.Buf, c...)
-  {{- else if .SingleByte }}
-  start := len(b.Buf)
-  b.Buf = append(b.Buf, make([]byte, len(c))...)
-  for i := range c {
-	b.Buf[i + start] = {{ .UnsignedType }}(c[i])
-  }
-  {{- else }}
-  const size = {{ .Bits }} / 8
-  offset := len(b.Buf)
-  b.Buf = append(b.Buf, make([]byte, size * len(c))...)
-  for _, v := range c {
-	{{ .BinPut }}(
-	  b.Buf[offset:offset+size],
-	{{- if .IsFloat }}
-	  math.{{ .Name }}bits(v),
-	{{- else if .Cast }}
-	  {{ .UnsignedType }}(v),
-	{{- else }}
-	  v,
-	{{- end }}
-	)
-	offset += size
-  }
-  {{- end }}
 }

--- a/proto/cmd/ch-gen-col/unsafe.tpl
+++ b/proto/cmd/ch-gen-col/unsafe.tpl
@@ -27,3 +27,25 @@ func (c *{{ .Type }}) DecodeColumn(r *Reader, rows int) error {
   }
   return nil
 }
+
+// EncodeColumn encodes {{ .Name }} rows to *Buffer.
+func (c {{ .Type }}) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+{{- if .SingleByte }}
+	b.Buf = append(b.Buf, make([]byte, len(c))...)
+{{- else }}
+	const size = {{ .Bits }} / 8
+	b.Buf = append(b.Buf, make([]byte, size * len(c))...)
+{{ end }}
+	s := *(*slice)(unsafe.Pointer(&c))
+{{- if not .SingleByte }}
+	s.Len *= {{ .Bytes }}
+	s.Cap *= {{ .Bytes }}
+{{- end }}
+	src := *(*[]byte)(unsafe.Pointer(&s))
+    dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_date32_gen.go
+++ b/proto/col_date32_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendDate32(data []Date32) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Date32 rows to *Buffer.
-func (c ColDate32) EncodeColumn(b *Buffer) {
-	const size = 32 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint32(
-			b.Buf[offset:offset+size],
-			uint32(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_date32_safe_gen.go
+++ b/proto/col_date32_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColDate32) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Date32 rows to *Buffer.
+func (c ColDate32) EncodeColumn(b *Buffer) {
+	const size = 32 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint32(
+			b.Buf[offset:offset+size],
+			uint32(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_date32_unsafe_gen.go
+++ b/proto/col_date32_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColDate32) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Date32 rows to *Buffer.
+func (c ColDate32) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 32 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 4
+	s.Cap *= 4
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_date_gen.go
+++ b/proto/col_date_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendDate(data []Date) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Date rows to *Buffer.
-func (c ColDate) EncodeColumn(b *Buffer) {
-	const size = 16 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint16(
-			b.Buf[offset:offset+size],
-			uint16(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_date_safe_gen.go
+++ b/proto/col_date_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColDate) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Date rows to *Buffer.
+func (c ColDate) EncodeColumn(b *Buffer) {
+	const size = 16 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint16(
+			b.Buf[offset:offset+size],
+			uint16(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_date_unsafe_gen.go
+++ b/proto/col_date_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColDate) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Date rows to *Buffer.
+func (c ColDate) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 16 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 2
+	s.Cap *= 2
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_datetime64_gen.go
+++ b/proto/col_datetime64_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendDateTime64(data []DateTime64) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes DateTime64 rows to *Buffer.
-func (c ColDateTime64) EncodeColumn(b *Buffer) {
-	const size = 64 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint64(
-			b.Buf[offset:offset+size],
-			uint64(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_datetime64_safe_gen.go
+++ b/proto/col_datetime64_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColDateTime64) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes DateTime64 rows to *Buffer.
+func (c ColDateTime64) EncodeColumn(b *Buffer) {
+	const size = 64 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint64(
+			b.Buf[offset:offset+size],
+			uint64(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_datetime64_unsafe_gen.go
+++ b/proto/col_datetime64_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColDateTime64) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes DateTime64 rows to *Buffer.
+func (c ColDateTime64) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 64 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 8
+	s.Cap *= 8
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_datetime_gen.go
+++ b/proto/col_datetime_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendDateTime(data []DateTime) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes DateTime rows to *Buffer.
-func (c ColDateTime) EncodeColumn(b *Buffer) {
-	const size = 32 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint32(
-			b.Buf[offset:offset+size],
-			uint32(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_datetime_safe_gen.go
+++ b/proto/col_datetime_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColDateTime) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes DateTime rows to *Buffer.
+func (c ColDateTime) EncodeColumn(b *Buffer) {
+	const size = 32 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint32(
+			b.Buf[offset:offset+size],
+			uint32(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_datetime_unsafe_gen.go
+++ b/proto/col_datetime_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColDateTime) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes DateTime rows to *Buffer.
+func (c ColDateTime) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 32 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 4
+	s.Cap *= 4
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_decimal128_gen.go
+++ b/proto/col_decimal128_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendDecimal128(data []Decimal128) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Decimal128 rows to *Buffer.
-func (c ColDecimal128) EncodeColumn(b *Buffer) {
-	const size = 128 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binPutUInt128(
-			b.Buf[offset:offset+size],
-			UInt128(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_decimal128_safe_gen.go
+++ b/proto/col_decimal128_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColDecimal128) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Decimal128 rows to *Buffer.
+func (c ColDecimal128) EncodeColumn(b *Buffer) {
+	const size = 128 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binPutUInt128(
+			b.Buf[offset:offset+size],
+			UInt128(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_decimal128_unsafe_gen.go
+++ b/proto/col_decimal128_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColDecimal128) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Decimal128 rows to *Buffer.
+func (c ColDecimal128) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 128 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 16
+	s.Cap *= 16
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_decimal256_gen.go
+++ b/proto/col_decimal256_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendDecimal256(data []Decimal256) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Decimal256 rows to *Buffer.
-func (c ColDecimal256) EncodeColumn(b *Buffer) {
-	const size = 256 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binPutUInt256(
-			b.Buf[offset:offset+size],
-			UInt256(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_decimal256_safe_gen.go
+++ b/proto/col_decimal256_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColDecimal256) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Decimal256 rows to *Buffer.
+func (c ColDecimal256) EncodeColumn(b *Buffer) {
+	const size = 256 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binPutUInt256(
+			b.Buf[offset:offset+size],
+			UInt256(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_decimal256_unsafe_gen.go
+++ b/proto/col_decimal256_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColDecimal256) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Decimal256 rows to *Buffer.
+func (c ColDecimal256) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 256 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 32
+	s.Cap *= 32
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_decimal32_gen.go
+++ b/proto/col_decimal32_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendDecimal32(data []Decimal32) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Decimal32 rows to *Buffer.
-func (c ColDecimal32) EncodeColumn(b *Buffer) {
-	const size = 32 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint32(
-			b.Buf[offset:offset+size],
-			uint32(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_decimal32_safe_gen.go
+++ b/proto/col_decimal32_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColDecimal32) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Decimal32 rows to *Buffer.
+func (c ColDecimal32) EncodeColumn(b *Buffer) {
+	const size = 32 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint32(
+			b.Buf[offset:offset+size],
+			uint32(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_decimal32_unsafe_gen.go
+++ b/proto/col_decimal32_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColDecimal32) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Decimal32 rows to *Buffer.
+func (c ColDecimal32) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 32 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 4
+	s.Cap *= 4
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_decimal64_gen.go
+++ b/proto/col_decimal64_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendDecimal64(data []Decimal64) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Decimal64 rows to *Buffer.
-func (c ColDecimal64) EncodeColumn(b *Buffer) {
-	const size = 64 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint64(
-			b.Buf[offset:offset+size],
-			uint64(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_decimal64_safe_gen.go
+++ b/proto/col_decimal64_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColDecimal64) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Decimal64 rows to *Buffer.
+func (c ColDecimal64) EncodeColumn(b *Buffer) {
+	const size = 64 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint64(
+			b.Buf[offset:offset+size],
+			uint64(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_decimal64_unsafe_gen.go
+++ b/proto/col_decimal64_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColDecimal64) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Decimal64 rows to *Buffer.
+func (c ColDecimal64) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 64 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 8
+	s.Cap *= 8
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_enum16_gen.go
+++ b/proto/col_enum16_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendEnum16(data []Enum16) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Enum16 rows to *Buffer.
-func (c ColEnum16) EncodeColumn(b *Buffer) {
-	const size = 16 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint16(
-			b.Buf[offset:offset+size],
-			uint16(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_enum16_safe_gen.go
+++ b/proto/col_enum16_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColEnum16) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Enum16 rows to *Buffer.
+func (c ColEnum16) EncodeColumn(b *Buffer) {
+	const size = 16 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint16(
+			b.Buf[offset:offset+size],
+			uint16(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_enum16_unsafe_gen.go
+++ b/proto/col_enum16_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColEnum16) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Enum16 rows to *Buffer.
+func (c ColEnum16) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 16 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 2
+	s.Cap *= 2
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_enum8_gen.go
+++ b/proto/col_enum8_gen.go
@@ -56,12 +56,3 @@ func (c *ColArr) AppendEnum8(data []Enum8) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Enum8 rows to *Buffer.
-func (c ColEnum8) EncodeColumn(b *Buffer) {
-	start := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, len(c))...)
-	for i := range c {
-		b.Buf[i+start] = uint8(c[i])
-	}
-}

--- a/proto/col_enum8_safe_gen.go
+++ b/proto/col_enum8_safe_gen.go
@@ -29,3 +29,12 @@ func (c *ColEnum8) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Enum8 rows to *Buffer.
+func (c ColEnum8) EncodeColumn(b *Buffer) {
+	start := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, len(c))...)
+	for i := range c {
+		b.Buf[i+start] = uint8(c[i])
+	}
+}

--- a/proto/col_enum8_unsafe_gen.go
+++ b/proto/col_enum8_unsafe_gen.go
@@ -23,3 +23,16 @@ func (c *ColEnum8) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Enum8 rows to *Buffer.
+func (c ColEnum8) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, len(c))...)
+	s := *(*slice)(unsafe.Pointer(&c))
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_float32_gen.go
+++ b/proto/col_float32_gen.go
@@ -4,7 +4,6 @@ package proto
 
 import (
 	"encoding/binary"
-	"math"
 )
 
 var _ = binary.LittleEndian // clickHouse uses LittleEndian
@@ -56,18 +55,4 @@ func (c *ColArr) AppendFloat32(data []float32) {
 	d := c.Data.(*ColFloat32)
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
-}
-
-// EncodeColumn encodes Float32 rows to *Buffer.
-func (c ColFloat32) EncodeColumn(b *Buffer) {
-	const size = 32 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint32(
-			b.Buf[offset:offset+size],
-			math.Float32bits(v),
-		)
-		offset += size
-	}
 }

--- a/proto/col_float32_safe_gen.go
+++ b/proto/col_float32_safe_gen.go
@@ -36,3 +36,17 @@ func (c *ColFloat32) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Float32 rows to *Buffer.
+func (c ColFloat32) EncodeColumn(b *Buffer) {
+	const size = 32 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint32(
+			b.Buf[offset:offset+size],
+			math.Float32bits(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_float32_unsafe_gen.go
+++ b/proto/col_float32_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColFloat32) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Float32 rows to *Buffer.
+func (c ColFloat32) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 32 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 4
+	s.Cap *= 4
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_float64_gen.go
+++ b/proto/col_float64_gen.go
@@ -4,7 +4,6 @@ package proto
 
 import (
 	"encoding/binary"
-	"math"
 )
 
 var _ = binary.LittleEndian // clickHouse uses LittleEndian
@@ -56,18 +55,4 @@ func (c *ColArr) AppendFloat64(data []float64) {
 	d := c.Data.(*ColFloat64)
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
-}
-
-// EncodeColumn encodes Float64 rows to *Buffer.
-func (c ColFloat64) EncodeColumn(b *Buffer) {
-	const size = 64 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint64(
-			b.Buf[offset:offset+size],
-			math.Float64bits(v),
-		)
-		offset += size
-	}
 }

--- a/proto/col_float64_safe_gen.go
+++ b/proto/col_float64_safe_gen.go
@@ -36,3 +36,17 @@ func (c *ColFloat64) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Float64 rows to *Buffer.
+func (c ColFloat64) EncodeColumn(b *Buffer) {
+	const size = 64 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint64(
+			b.Buf[offset:offset+size],
+			math.Float64bits(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_float64_unsafe_gen.go
+++ b/proto/col_float64_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColFloat64) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Float64 rows to *Buffer.
+func (c ColFloat64) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 64 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 8
+	s.Cap *= 8
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_int128_gen.go
+++ b/proto/col_int128_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendInt128(data []Int128) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Int128 rows to *Buffer.
-func (c ColInt128) EncodeColumn(b *Buffer) {
-	const size = 128 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binPutUInt128(
-			b.Buf[offset:offset+size],
-			UInt128(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_int128_safe_gen.go
+++ b/proto/col_int128_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColInt128) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Int128 rows to *Buffer.
+func (c ColInt128) EncodeColumn(b *Buffer) {
+	const size = 128 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binPutUInt128(
+			b.Buf[offset:offset+size],
+			UInt128(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_int128_unsafe_gen.go
+++ b/proto/col_int128_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColInt128) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Int128 rows to *Buffer.
+func (c ColInt128) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 128 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 16
+	s.Cap *= 16
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_int16_gen.go
+++ b/proto/col_int16_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendInt16(data []int16) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Int16 rows to *Buffer.
-func (c ColInt16) EncodeColumn(b *Buffer) {
-	const size = 16 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint16(
-			b.Buf[offset:offset+size],
-			uint16(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_int16_safe_gen.go
+++ b/proto/col_int16_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColInt16) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Int16 rows to *Buffer.
+func (c ColInt16) EncodeColumn(b *Buffer) {
+	const size = 16 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint16(
+			b.Buf[offset:offset+size],
+			uint16(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_int16_unsafe_gen.go
+++ b/proto/col_int16_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColInt16) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Int16 rows to *Buffer.
+func (c ColInt16) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 16 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 2
+	s.Cap *= 2
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_int256_gen.go
+++ b/proto/col_int256_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendInt256(data []Int256) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Int256 rows to *Buffer.
-func (c ColInt256) EncodeColumn(b *Buffer) {
-	const size = 256 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binPutUInt256(
-			b.Buf[offset:offset+size],
-			UInt256(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_int256_safe_gen.go
+++ b/proto/col_int256_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColInt256) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Int256 rows to *Buffer.
+func (c ColInt256) EncodeColumn(b *Buffer) {
+	const size = 256 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binPutUInt256(
+			b.Buf[offset:offset+size],
+			UInt256(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_int256_unsafe_gen.go
+++ b/proto/col_int256_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColInt256) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Int256 rows to *Buffer.
+func (c ColInt256) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 256 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 32
+	s.Cap *= 32
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_int32_gen.go
+++ b/proto/col_int32_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendInt32(data []int32) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Int32 rows to *Buffer.
-func (c ColInt32) EncodeColumn(b *Buffer) {
-	const size = 32 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint32(
-			b.Buf[offset:offset+size],
-			uint32(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_int32_safe_gen.go
+++ b/proto/col_int32_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColInt32) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Int32 rows to *Buffer.
+func (c ColInt32) EncodeColumn(b *Buffer) {
+	const size = 32 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint32(
+			b.Buf[offset:offset+size],
+			uint32(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_int32_unsafe_gen.go
+++ b/proto/col_int32_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColInt32) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Int32 rows to *Buffer.
+func (c ColInt32) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 32 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 4
+	s.Cap *= 4
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_int64_gen.go
+++ b/proto/col_int64_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendInt64(data []int64) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Int64 rows to *Buffer.
-func (c ColInt64) EncodeColumn(b *Buffer) {
-	const size = 64 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint64(
-			b.Buf[offset:offset+size],
-			uint64(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_int64_safe_gen.go
+++ b/proto/col_int64_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColInt64) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Int64 rows to *Buffer.
+func (c ColInt64) EncodeColumn(b *Buffer) {
+	const size = 64 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint64(
+			b.Buf[offset:offset+size],
+			uint64(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_int64_unsafe_gen.go
+++ b/proto/col_int64_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColInt64) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Int64 rows to *Buffer.
+func (c ColInt64) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 64 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 8
+	s.Cap *= 8
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_int8_gen.go
+++ b/proto/col_int8_gen.go
@@ -56,12 +56,3 @@ func (c *ColArr) AppendInt8(data []int8) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes Int8 rows to *Buffer.
-func (c ColInt8) EncodeColumn(b *Buffer) {
-	start := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, len(c))...)
-	for i := range c {
-		b.Buf[i+start] = uint8(c[i])
-	}
-}

--- a/proto/col_int8_safe_gen.go
+++ b/proto/col_int8_safe_gen.go
@@ -29,3 +29,12 @@ func (c *ColInt8) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes Int8 rows to *Buffer.
+func (c ColInt8) EncodeColumn(b *Buffer) {
+	start := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, len(c))...)
+	for i := range c {
+		b.Buf[i+start] = uint8(c[i])
+	}
+}

--- a/proto/col_int8_unsafe_gen.go
+++ b/proto/col_int8_unsafe_gen.go
@@ -23,3 +23,16 @@ func (c *ColInt8) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes Int8 rows to *Buffer.
+func (c ColInt8) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, len(c))...)
+	s := *(*slice)(unsafe.Pointer(&c))
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_ipv4_gen.go
+++ b/proto/col_ipv4_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendIPv4(data []IPv4) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes IPv4 rows to *Buffer.
-func (c ColIPv4) EncodeColumn(b *Buffer) {
-	const size = 32 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint32(
-			b.Buf[offset:offset+size],
-			uint32(v),
-		)
-		offset += size
-	}
-}

--- a/proto/col_ipv4_safe_gen.go
+++ b/proto/col_ipv4_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColIPv4) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes IPv4 rows to *Buffer.
+func (c ColIPv4) EncodeColumn(b *Buffer) {
+	const size = 32 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint32(
+			b.Buf[offset:offset+size],
+			uint32(v),
+		)
+		offset += size
+	}
+}

--- a/proto/col_ipv4_unsafe_gen.go
+++ b/proto/col_ipv4_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColIPv4) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes IPv4 rows to *Buffer.
+func (c ColIPv4) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 32 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 4
+	s.Cap *= 4
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_ipv6_gen.go
+++ b/proto/col_ipv6_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendIPv6(data []IPv6) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes IPv6 rows to *Buffer.
-func (c ColIPv6) EncodeColumn(b *Buffer) {
-	const size = 128 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binPutIPv6(
-			b.Buf[offset:offset+size],
-			v,
-		)
-		offset += size
-	}
-}

--- a/proto/col_ipv6_safe_gen.go
+++ b/proto/col_ipv6_safe_gen.go
@@ -33,3 +33,17 @@ func (c *ColIPv6) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes IPv6 rows to *Buffer.
+func (c ColIPv6) EncodeColumn(b *Buffer) {
+	const size = 128 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binPutIPv6(
+			b.Buf[offset:offset+size],
+			v,
+		)
+		offset += size
+	}
+}

--- a/proto/col_uint128_gen.go
+++ b/proto/col_uint128_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendUInt128(data []UInt128) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes UInt128 rows to *Buffer.
-func (c ColUInt128) EncodeColumn(b *Buffer) {
-	const size = 128 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binPutUInt128(
-			b.Buf[offset:offset+size],
-			v,
-		)
-		offset += size
-	}
-}

--- a/proto/col_uint128_safe_gen.go
+++ b/proto/col_uint128_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColUInt128) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes UInt128 rows to *Buffer.
+func (c ColUInt128) EncodeColumn(b *Buffer) {
+	const size = 128 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binPutUInt128(
+			b.Buf[offset:offset+size],
+			v,
+		)
+		offset += size
+	}
+}

--- a/proto/col_uint128_unsafe_gen.go
+++ b/proto/col_uint128_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColUInt128) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes UInt128 rows to *Buffer.
+func (c ColUInt128) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 128 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 16
+	s.Cap *= 16
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_uint16_gen.go
+++ b/proto/col_uint16_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendUInt16(data []uint16) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes UInt16 rows to *Buffer.
-func (c ColUInt16) EncodeColumn(b *Buffer) {
-	const size = 16 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint16(
-			b.Buf[offset:offset+size],
-			v,
-		)
-		offset += size
-	}
-}

--- a/proto/col_uint16_safe_gen.go
+++ b/proto/col_uint16_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColUInt16) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes UInt16 rows to *Buffer.
+func (c ColUInt16) EncodeColumn(b *Buffer) {
+	const size = 16 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint16(
+			b.Buf[offset:offset+size],
+			v,
+		)
+		offset += size
+	}
+}

--- a/proto/col_uint16_unsafe_gen.go
+++ b/proto/col_uint16_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColUInt16) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes UInt16 rows to *Buffer.
+func (c ColUInt16) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 16 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 2
+	s.Cap *= 2
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_uint256_gen.go
+++ b/proto/col_uint256_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendUInt256(data []UInt256) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes UInt256 rows to *Buffer.
-func (c ColUInt256) EncodeColumn(b *Buffer) {
-	const size = 256 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binPutUInt256(
-			b.Buf[offset:offset+size],
-			v,
-		)
-		offset += size
-	}
-}

--- a/proto/col_uint256_safe_gen.go
+++ b/proto/col_uint256_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColUInt256) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes UInt256 rows to *Buffer.
+func (c ColUInt256) EncodeColumn(b *Buffer) {
+	const size = 256 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binPutUInt256(
+			b.Buf[offset:offset+size],
+			v,
+		)
+		offset += size
+	}
+}

--- a/proto/col_uint256_unsafe_gen.go
+++ b/proto/col_uint256_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColUInt256) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes UInt256 rows to *Buffer.
+func (c ColUInt256) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 256 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 32
+	s.Cap *= 32
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_uint32_gen.go
+++ b/proto/col_uint32_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendUInt32(data []uint32) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes UInt32 rows to *Buffer.
-func (c ColUInt32) EncodeColumn(b *Buffer) {
-	const size = 32 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint32(
-			b.Buf[offset:offset+size],
-			v,
-		)
-		offset += size
-	}
-}

--- a/proto/col_uint32_safe_gen.go
+++ b/proto/col_uint32_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColUInt32) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes UInt32 rows to *Buffer.
+func (c ColUInt32) EncodeColumn(b *Buffer) {
+	const size = 32 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint32(
+			b.Buf[offset:offset+size],
+			v,
+		)
+		offset += size
+	}
+}

--- a/proto/col_uint32_unsafe_gen.go
+++ b/proto/col_uint32_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColUInt32) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes UInt32 rows to *Buffer.
+func (c ColUInt32) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 32 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 4
+	s.Cap *= 4
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_uint64_gen.go
+++ b/proto/col_uint64_gen.go
@@ -56,17 +56,3 @@ func (c *ColArr) AppendUInt64(data []uint64) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes UInt64 rows to *Buffer.
-func (c ColUInt64) EncodeColumn(b *Buffer) {
-	const size = 64 / 8
-	offset := len(b.Buf)
-	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
-	for _, v := range c {
-		binary.LittleEndian.PutUint64(
-			b.Buf[offset:offset+size],
-			v,
-		)
-		offset += size
-	}
-}

--- a/proto/col_uint64_safe_gen.go
+++ b/proto/col_uint64_safe_gen.go
@@ -35,3 +35,17 @@ func (c *ColUInt64) DecodeColumn(r *Reader, rows int) error {
 	*c = v
 	return nil
 }
+
+// EncodeColumn encodes UInt64 rows to *Buffer.
+func (c ColUInt64) EncodeColumn(b *Buffer) {
+	const size = 64 / 8
+	offset := len(b.Buf)
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+	for _, v := range c {
+		binary.LittleEndian.PutUint64(
+			b.Buf[offset:offset+size],
+			v,
+		)
+		offset += size
+	}
+}

--- a/proto/col_uint64_unsafe_gen.go
+++ b/proto/col_uint64_unsafe_gen.go
@@ -25,3 +25,20 @@ func (c *ColUInt64) DecodeColumn(r *Reader, rows int) error {
 	}
 	return nil
 }
+
+// EncodeColumn encodes UInt64 rows to *Buffer.
+func (c ColUInt64) EncodeColumn(b *Buffer) {
+	if len(c) == 0 {
+		return
+	}
+	offset := len(b.Buf)
+	const size = 64 / 8
+	b.Buf = append(b.Buf, make([]byte, size*len(c))...)
+
+	s := *(*slice)(unsafe.Pointer(&c))
+	s.Len *= 8
+	s.Cap *= 8
+	src := *(*[]byte)(unsafe.Pointer(&s))
+	dst := b.Buf[offset:]
+	copy(dst, src)
+}

--- a/proto/col_uint8_gen.go
+++ b/proto/col_uint8_gen.go
@@ -56,8 +56,3 @@ func (c *ColArr) AppendUInt8(data []uint8) {
 	*d = append(*d, data...)
 	c.Offsets = append(c.Offsets, uint64(len(*d)))
 }
-
-// EncodeColumn encodes UInt8 rows to *Buffer.
-func (c ColUInt8) EncodeColumn(b *Buffer) {
-	b.Buf = append(b.Buf, c...)
-}

--- a/proto/col_uint8_safe_gen.go
+++ b/proto/col_uint8_safe_gen.go
@@ -22,3 +22,8 @@ func (c *ColUInt8) DecodeColumn(r *Reader, rows int) error {
 	*c = append(*c, data...)
 	return nil
 }
+
+// EncodeColumn encodes UInt8 rows to *Buffer.
+func (c ColUInt8) EncodeColumn(b *Buffer) {
+	b.Buf = append(b.Buf, c...)
+}


### PR DESCRIPTION
```
name                           old time/op    new time/op     delta
ColBool_Raw_EncodeColumn-32       701ns ± 1%      702ns ± 0%       ~     (p=0.635 n=5+5)
ClientHello_Encode-32            34.5ns ± 0%     34.8ns ± 1%       ~     (p=0.063 n=5+5)
ColBool_EncodeColumn-32          28.1µs ± 2%     30.2µs ± 1%     +7.61%  (p=0.008 n=5+5)
ColDate32_EncodeColumn-32         688ns ± 1%       59ns ± 2%    -91.41%  (p=0.008 n=5+5)
ColDate_EncodeColumn-32           679ns ± 1%       33ns ± 1%    -95.21%  (p=0.016 n=4+5)
ColDateTime64_EncodeColumn-32     718ns ± 2%      114ns ± 0%    -84.17%  (p=0.029 n=4+4)
ColDateTime_EncodeColumn-32       697ns ± 3%       59ns ± 0%    -91.59%  (p=0.008 n=5+5)
ColDecimal128_EncodeColumn-32    2.53µs ± 3%     0.23µs ± 1%    -91.01%  (p=0.008 n=5+5)
ColDecimal256_EncodeColumn-32    3.14µs ± 3%     0.68µs ± 2%    -78.27%  (p=0.008 n=5+5)
ColDecimal32_EncodeColumn-32      715ns ±12%       58ns ± 2%    -91.85%  (p=0.008 n=5+5)
ColDecimal64_EncodeColumn-32      729ns ± 8%      114ns ± 0%    -84.36%  (p=0.008 n=5+5)
ColEnum16_EncodeColumn-32         680ns ± 2%       33ns ± 1%    -95.20%  (p=0.008 n=5+5)
ColEnum8_EncodeColumn-32          531ns ± 1%       19ns ± 2%    -96.50%  (p=0.008 n=5+5)
ColFixedStr_EncodeColumn-32       441ns ± 2%      439ns ± 0%       ~     (p=0.310 n=5+5)
ColFloat32_EncodeColumn-32        594ns ± 2%       59ns ± 1%    -90.04%  (p=0.008 n=5+5)
ColFloat64_EncodeColumn-32        713ns ± 2%      114ns ± 0%    -84.02%  (p=0.008 n=5+5)
ColInt128_EncodeColumn-32        2.44µs ± 2%     0.23µs ± 1%    -90.69%  (p=0.008 n=5+5)
ColInt16_EncodeColumn-32          672ns ± 2%       33ns ± 1%    -95.15%  (p=0.008 n=5+5)
ColInt256_EncodeColumn-32        3.10µs ± 5%     0.69µs ± 1%    -77.82%  (p=0.008 n=5+5)
ColInt32_EncodeColumn-32          690ns ± 2%       59ns ± 2%    -91.42%  (p=0.008 n=5+5)
ColInt64_EncodeColumn-32          712ns ± 1%      114ns ± 1%    -83.98%  (p=0.008 n=5+5)
ColInt8_EncodeColumn-32           531ns ± 5%       18ns ± 1%    -96.53%  (p=0.008 n=5+5)
ColIPv4_EncodeColumn-32           704ns ±10%       59ns ± 1%    -91.66%  (p=0.008 n=5+5)
ColIPv6_EncodeColumn-32          2.39µs ± 4%     2.34µs ± 3%       ~     (p=0.151 n=5+5)
ColRaw_EncodeColumn-32           12.5ns ± 2%     12.7ns ± 1%       ~     (p=0.095 n=5+5)
ColStr_EncodeColumn-32           6.28µs ± 1%     6.72µs ± 0%     +6.98%  (p=0.008 n=5+5)
ColTuple_EncodeColumn-32         2.12µs ± 1%     2.14µs ± 2%       ~     (p=0.278 n=5+5)
ColUInt128_EncodeColumn-32       2.33µs ± 1%     0.23µs ± 1%    -90.27%  (p=0.008 n=5+5)
ColUInt16_EncodeColumn-32         681ns ± 1%       33ns ± 0%    -95.22%  (p=0.008 n=5+5)
ColUInt256_EncodeColumn-32       3.14µs ± 3%     0.69µs ± 1%    -78.14%  (p=0.008 n=5+5)
ColUInt32_EncodeColumn-32         687ns ± 3%       59ns ± 1%    -91.44%  (p=0.008 n=5+5)
ColUInt64_EncodeColumn-32         726ns ± 8%      113ns ± 2%    -84.44%  (p=0.008 n=5+5)
ColUInt8_EncodeColumn-32         9.24ns ± 1%     9.30ns ± 1%       ~     (p=0.310 n=5+5)
ColUUID_EncodeColumn-32          1.19µs ± 4%     1.16µs ± 0%       ~     (p=0.548 n=5+5)

name                           old speed      new speed       delta
ColBool_Raw_EncodeColumn-32    71.4GB/s ± 1%   71.2GB/s ± 0%       ~     (p=0.690 n=5+5)
ClientHello_Encode-32          1.59GB/s ± 0%   1.58GB/s ± 1%       ~     (p=0.056 n=5+5)
ColBool_EncodeColumn-32        1.78GB/s ± 2%   1.66GB/s ± 1%     -7.07%  (p=0.008 n=5+5)
ColDate32_EncodeColumn-32      5.81GB/s ± 2%  67.72GB/s ± 2%  +1064.76%  (p=0.008 n=5+5)
ColDate_EncodeColumn-32        2.94GB/s ± 1%  61.51GB/s ± 1%  +1989.42%  (p=0.016 n=4+5)
ColDateTime64_EncodeColumn-32  10.9GB/s ± 8%   70.4GB/s ± 0%   +544.82%  (p=0.016 n=5+4)
ColDateTime_EncodeColumn-32    5.74GB/s ± 3%  68.28GB/s ± 0%  +1088.88%  (p=0.008 n=5+5)
ColDecimal128_EncodeColumn-32  6.33GB/s ± 3%  70.41GB/s ± 1%  +1012.50%  (p=0.008 n=5+5)
ColDecimal256_EncodeColumn-32  10.2GB/s ± 3%   46.9GB/s ± 2%   +360.19%  (p=0.008 n=5+5)
ColDecimal32_EncodeColumn-32   5.61GB/s ±11%  68.62GB/s ± 2%  +1122.26%  (p=0.008 n=5+5)
ColDecimal64_EncodeColumn-32   11.0GB/s ± 7%   70.1GB/s ± 0%   +538.15%  (p=0.008 n=5+5)
ColEnum16_EncodeColumn-32      2.94GB/s ± 2%  61.22GB/s ± 1%  +1981.30%  (p=0.008 n=5+5)
ColEnum8_EncodeColumn-32       1.88GB/s ± 1%  53.89GB/s ± 2%  +2759.73%  (p=0.008 n=5+5)
ColFixedStr_EncodeColumn-32    72.5GB/s ± 2%   72.9GB/s ± 0%       ~     (p=0.310 n=5+5)
ColFloat32_EncodeColumn-32     6.73GB/s ± 2%  67.61GB/s ± 1%   +904.19%  (p=0.008 n=5+5)
ColFloat64_EncodeColumn-32     11.2GB/s ± 2%   70.3GB/s ± 0%   +525.84%  (p=0.008 n=5+5)
ColInt128_EncodeColumn-32      6.57GB/s ± 2%  70.54GB/s ± 1%   +974.23%  (p=0.008 n=5+5)
ColInt16_EncodeColumn-32       2.98GB/s ± 2%  61.46GB/s ± 1%  +1963.38%  (p=0.008 n=5+5)
ColInt256_EncodeColumn-32      10.3GB/s ± 5%   46.6GB/s ± 1%   +350.56%  (p=0.008 n=5+5)
ColInt32_EncodeColumn-32       5.80GB/s ± 2%  67.62GB/s ± 2%  +1065.42%  (p=0.008 n=5+5)
ColInt64_EncodeColumn-32       11.2GB/s ± 1%   70.2GB/s ± 1%   +524.41%  (p=0.008 n=5+5)
ColInt8_EncodeColumn-32        1.88GB/s ± 5%  54.23GB/s ± 1%  +2778.57%  (p=0.008 n=5+5)
ColIPv4_EncodeColumn-32        5.69GB/s ± 9%  68.11GB/s ± 1%  +1096.47%  (p=0.008 n=5+5)
ColIPv6_EncodeColumn-32        6.70GB/s ± 4%   6.85GB/s ± 3%       ~     (p=0.151 n=5+5)
ColRaw_EncodeColumn-32         81.9GB/s ± 2%   80.4GB/s ± 1%       ~     (p=0.095 n=5+5)
ColStr_EncodeColumn-32         5.26GB/s ± 1%   4.91GB/s ± 0%     -6.53%  (p=0.008 n=5+5)
ColTuple_EncodeColumn-32       70.7GB/s ± 1%   70.2GB/s ± 2%       ~     (p=0.310 n=5+5)
ColUInt128_EncodeColumn-32     6.86GB/s ± 1%  70.50GB/s ± 1%   +928.05%  (p=0.008 n=5+5)
ColUInt16_EncodeColumn-32      2.94GB/s ± 1%  61.43GB/s ± 0%  +1991.95%  (p=0.008 n=5+5)
ColUInt256_EncodeColumn-32     10.2GB/s ± 3%   46.6GB/s ± 1%   +357.29%  (p=0.008 n=5+5)
ColUInt32_EncodeColumn-32      5.82GB/s ± 3%  68.02GB/s ± 1%  +1067.81%  (p=0.008 n=5+5)
ColUInt64_EncodeColumn-32      11.0GB/s ± 8%   70.8GB/s ± 2%   +541.62%  (p=0.008 n=5+5)
ColUInt8_EncodeColumn-32        108GB/s ± 1%    108GB/s ± 1%       ~     (p=0.310 n=5+5)
ColUUID_EncodeColumn-32        13.4GB/s ± 4%   13.7GB/s ± 0%       ~     (p=0.548 n=5+5)
```