### PR TITLE
support LowCardinality(String) for auto result

### DIFF
--- a/proto/col_auto.go
+++ b/proto/col_auto.go
@@ -21,7 +21,17 @@ func (c *ColAuto) Infer(t ColumnType) error {
 		c.Data = new(ColStr)
 	case ColumnTypeBool:
 		c.Data = new(ColBool)
+
 	default:
+		if t.Base() == ColumnTypeLowCardinality {
+			elem := t.Elem()
+			if elem == ColumnTypeString {
+				c.Data = &ColLowCardinality{
+					Index: new(ColStr),
+				}
+				return nil
+			}
+		}
 		return errors.Errorf("automatic column inference not supported for %q", t)
 	}
 

--- a/proto/col_auto_test.go
+++ b/proto/col_auto_test.go
@@ -28,6 +28,7 @@ func TestColAuto_Infer(t *testing.T) {
 		ColumnTypeFloat64,
 		ColumnTypeIPv4,
 		ColumnTypeIPv6,
+		ColumnTypeLowCardinality.Sub(ColumnTypeString),
 	} {
 		auto := r.Data.(InferColumn)
 		require.NoError(t, auto.Infer(columnType))


### PR DESCRIPTION
Support LowCardinality(String) for auto result. Test modified also.